### PR TITLE
add zero trust postgrest worker example

### DIFF
--- a/terraform-zerotrust-postgrest-worker/.gitignore
+++ b/terraform-zerotrust-postgrest-worker/.gitignore
@@ -1,0 +1,33 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+terraform.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+*tfplan*
+*.plan*
+*lock*

--- a/terraform-zerotrust-postgrest-worker/README.md
+++ b/terraform-zerotrust-postgrest-worker/README.md
@@ -30,11 +30,11 @@
 Typically takes ~5 mins to fully spin up. 
 
 This demo 
-- creates a Google Cloud (GCP) instance running an [PostgreSQL](https://hub.docker.com/_/postgres) and [PostgREST](https://hub.docker.com/r/postgrest/postgrest/) docker container.
-- spins up a Cloudflare Tunnel on the GCP instance proxying traffic to the PostgREST container
-and the local SSH port on the server
-- deploys Cloudflare Worker (+route) that is using Cloudflare Access service tokens to access the protected PostgREST endpoint
-- creates DNS records at Cloudflare to point to the tunnel endpoints and for the [example Worker](./cloudflare-worker-script.js)
+- Creates a Google Cloud (GCP) instance running an [PostgreSQL](https://hub.docker.com/_/postgres) and [PostgREST](https://hub.docker.com/r/postgrest/postgrest/) docker container.
+- Spins up a Cloudflare Tunnel on the GCP instance proxying traffic to the PostgREST container 
+and the local SSH port on the server.
+- Deploys Cloudflare Worker (+route) that is using Cloudflare Access service tokens to access the protected PostgREST endpoint.
+- Creates DNS records at Cloudflare to point to the tunnel endpoints and for the [example Worker](./cloudflare-worker-script.js).
 
 The GCP instance is set to not accept SSH traffic via a `no-ssh` tag. Your Firewall settings may differ and this may need to be adjusted as needed.
 
@@ -43,7 +43,7 @@ An access policy is created for
 - `zerotrust-postgrest-example.yourzone.com` _(or your configured subdomain via `TF_VAR_cloudflare_postgrest_subdomain` variable)_
 - `zerotrust-worker-example.yourzone.com` _(or your configured subdomain via `TF_VAR_cloudflare_worker_subdomain` variable)_
 
-The only person allowed to all of them is the user provided to `TF_VAR_cloudflare_email` environment variable.
+The only person allowed to use all of them is the user provided to `TF_VAR_cloudflare_email` environment variable.
 
 ## Zero Trust access to your instance
 ### local SSH
@@ -64,8 +64,9 @@ You can then `ssh user@zerotrust-ssh-example.yourzone.com` where user is your OS
 Where `yourzone.com` is the zone assigned to `TF_VAR_cloudflare_zone` environment variable.
 
 - `zerotrust-ssh-example.yourzone.com` Access protected for SSH access, exposed with Cloudflare Tunnel
-- `zerotrust-postgrest-example.yourzone.com` Access PostgREST (PostgreSQL proxy), exposed with Cloudflare Tunnel
-- `zerotrust-worker-example.yourzone.com` publicly available [example Worker](./cloudflare-worker-script.js) querying PostgREST from the Cloudflare Edge, using Cloudflare Access service token
+- `zerotrust-postgrest-example.yourzone.com` Access protected PostgREST (PostgreSQL proxy), exposed with Cloudflare Tunnel
+    PostgREST is not publicly available, in this example we use Workers as the point of contact so we can easily leverage auth or caching within Workers KV/Cache API.
+- `zerotrust-worker-example.yourzone.com` publicly available [example Worker](./cloudflare-worker-script.js) querying PostgREST from the Cloudflare Edge, using Cloudflare Access service token to access the protected PostgREST Cloudflare Tunnel.
 
 ## The fun
 The demo has very simple functionality, you can 
@@ -73,7 +74,23 @@ The demo has very simple functionality, you can
 - get a list of all users (https://zerotrust-worker-example.yourzone.com)
 - get a list of all users filtered by country (https://zerotrust-worker-example.yourzone.com/?country=ireland)
 
-## Tips
+## Bonus - Run this setup on any host you have SSH access to
+Set following environment variables to disable GCP deployment and deploy to any host instead. Tested on Ubuntu 20.04 and 21.04 (amd64).
+
+1. Set environment to configure SSH connection
+    ```bash
+    # IP address accessible from your machine
+    export TF_VAR_ssh_host_ip=
+    export TF_VAR_ssh_host_port= # defaults to 22
+    # if you use user/password combination
+    export TF_VAR_ssh_user= # defaults to "ubuntu"
+    export TF_VAR_ssh_password= 
+    # or you use SSH key
+    export TF_VAR_ssh_key_path=
+    ```
+2. Run `terraform apply` to configure the remote instance as the origin with PostgREST for your Cloudflare Tunnel
+
+## Tips
 - [supabase/postgrest-js](https://github.com/supabase/postgrest-js) library is fully compatible with any postgrest instance
     ```javascript
     const REST_URL = 'https://zerotrust-worker-example.yourzone.com'
@@ -87,4 +104,4 @@ The demo has very simple functionality, you can
         .from('example_table')
         .insert(records)
     ```
-- You can also use [SSH Web Terminal](https://blog.cloudflare.com/browser-ssh-terminal-with-auditing/), this was not included as there is no Terraform support for the SSH-enabled Access Policy yet
+- You can also use [SSH Web Terminal](https://blog.cloudflare.com/browser-ssh-terminal-with-auditing/), but you need to enable it manually in Cloudflare Teams. This was not included as there is no Terraform support for the SSH-enabled Access Policy yet. 

--- a/terraform-zerotrust-postgrest-worker/README.md
+++ b/terraform-zerotrust-postgrest-worker/README.md
@@ -1,0 +1,90 @@
+# Automated Cloudflare Tunnel pointing to PostgREST (PostgreSQL proxy) + Zero Trust Access from Workers
+
+1. Copy repo to your local workstation
+2. Change directory (cd) to the repo's location on your local workstation
+3. Set the following environment variables
+    ```bash
+    # required
+    export TF_VAR_gcp_project_id=
+    export TF_VAR_cloudflare_account_id=
+    export TF_VAR_cloudflare_zone=
+    export TF_VAR_cloudflare_email=
+    export TF_VAR_cloudflare_token=
+    # optional, defaults to following values
+    export TF_VAR_gcp_zone=us-east1-b
+    export TF_VAR_gcp_machine_type=f1-micro
+    export TF_VAR_cloudflare_ssh_subdomain=zerotrust-ssh-example
+    export TF_VAR_cloudflare_postgrest_subdomain=zerotrust-postgrest-example
+    export TF_VAR_cloudflare_worker_subdomain=zerotrust-worker-example
+    ```
+4. Run `terraform apply` to initiate config
+
+## Requirements
+
+- Terraform version 0.13 +
+- GCP (Google Cloud) cli setup and [authenticated to a GCP project](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) with compute access. 
+- Cloudflare account and zone with at least 1 Access seat
+
+## Setup
+
+Typically takes ~5 mins to fully spin up. 
+
+This demo 
+- creates a Google Cloud (GCP) instance running an [PostgreSQL](https://hub.docker.com/_/postgres) and [PostgREST](https://hub.docker.com/r/postgrest/postgrest/) docker container.
+- spins up a Cloudflare Tunnel on the GCP instance proxying traffic to the PostgREST container
+and the local SSH port on the server
+- deploys Cloudflare Worker (+route) that is using Cloudflare Access service tokens to access the protected PostgREST endpoint
+- creates DNS records at Cloudflare to point to the tunnel endpoints and for the [example Worker](./cloudflare-worker-script.js)
+
+The GCP instance is set to not accept SSH traffic via a `no-ssh` tag. Your Firewall settings may differ and this may need to be adjusted as needed.
+
+An access policy is created for 
+- `zerotrust-ssh-example.yourzone.com` _(or your configured subdomain via `TF_VAR_cloudflare_ssh_subdomain` variable)_ 
+- `zerotrust-postgrest-example.yourzone.com` _(or your configured subdomain via `TF_VAR_cloudflare_postgrest_subdomain` variable)_
+- `zerotrust-worker-example.yourzone.com` _(or your configured subdomain via `TF_VAR_cloudflare_worker_subdomain` variable)_
+
+The only person allowed to all of them is the user provided to `TF_VAR_cloudflare_email` environment variable.
+
+## Zero Trust access to your instance
+### local SSH
+Update your workstation's SSH config to provide a specific host block for `zerotrust-ssh-example.yourzone.com`.
+
+Here is an example:
+
+```
+Host zerotrust-ssh-example.yourzone.com
+    IdentityFile /Users/user/.ssh/google_compute_engine
+    ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
+```
+
+You can then `ssh user@zerotrust-ssh-example.yourzone.com` where user is your OS user to login.
+
+## Endpoints
+
+Where `yourzone.com` is the zone assigned to `TF_VAR_cloudflare_zone` environment variable.
+
+- `zerotrust-ssh-example.yourzone.com` Access protected for SSH access, exposed with Cloudflare Tunnel
+- `zerotrust-postgrest-example.yourzone.com` Access PostgREST (PostgreSQL proxy), exposed with Cloudflare Tunnel
+- `zerotrust-worker-example.yourzone.com` publicly available [example Worker](./cloudflare-worker-script.js) querying PostgREST from the Cloudflare Edge, using Cloudflare Access service token
+
+## The fun
+The demo has very simple functionality, you can 
+- generate a new user visit (https://zerotrust-worker-example.yourzone.com/new)
+- get a list of all users (https://zerotrust-worker-example.yourzone.com)
+- get a list of all users filtered by country (https://zerotrust-worker-example.yourzone.com/?country=ireland)
+
+## Tips
+- [supabase/postgrest-js](https://github.com/supabase/postgrest-js) library is fully compatible with any postgrest instance
+    ```javascript
+    const REST_URL = 'https://zerotrust-worker-example.yourzone.com'
+    const postgrest = new PostgrestClient(REST_URL, {
+      headers: {
+        'CF-Access-Client-Id': CF_ACCESS_CLIENT_ID,
+        'CF-Access-Client-Secret': CF_ACCESS_CLIENT_SECRET,
+      }
+    })
+    const { data, error } = await postgrest
+        .from('example_table')
+        .insert(records)
+    ```
+- You can also use [SSH Web Terminal](https://blog.cloudflare.com/browser-ssh-terminal-with-auditing/), this was not included as there is no Terraform support for the SSH-enabled Access Policy yet

--- a/terraform-zerotrust-postgrest-worker/bonus-any-ssh-host.tf
+++ b/terraform-zerotrust-postgrest-worker/bonus-any-ssh-host.tf
@@ -1,0 +1,34 @@
+# this is bonus file, to switch to any SSH host, set the SSH host variables
+# this resource will trigger connection to any SSH host and copy/run the installation script
+resource "null_resource" "any_ssh_host" {
+  # only run when var.ssh_host_ip is defined
+  count = var.ssh_host_ip != "" ? 1 : 0
+
+  # it will automatically rerun on any triggers change
+  # or you can run `terraform taint "null_resource.any_ssh_host[0]"` which will plan resource to recreate
+  triggers = {
+    ip        = var.ssh_host_ip
+    tunnel_id = cloudflare_argo_tunnel.auto_tunnel.id
+  }
+
+  connection {
+    host        = var.ssh_host_ip
+    port        = var.ssh_host_port
+    user        = var.ssh_user
+    private_key = fileexists(var.ssh_key_path) ? file(var.ssh_key_path) : ""
+    password    = var.ssh_password
+    timeout     = "600s" # 10 minutes should be enough to complete all steps, increase if needed
+  }
+
+  provisioner "file" {
+    content     = local.startup_script
+    destination = "/tmp/install-script.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /tmp/install-script.sh",
+      "/tmp/install-script.sh",
+    ]
+  }
+}

--- a/terraform-zerotrust-postgrest-worker/cloudflare-access.tf
+++ b/terraform-zerotrust-postgrest-worker/cloudflare-access.tf
@@ -1,0 +1,55 @@
+data "cloudflare_zones" "zones" {
+  filter {
+    name        = var.cloudflare_zone
+    lookup_type = "exact"
+    status      = "active"
+  }
+}
+
+locals {
+  cloudflare_zone_id = lookup(element(data.cloudflare_zones.zones.zones, 0), "id")
+}
+
+# Access application to apply zero trust policy over SSH endpoint
+resource "cloudflare_access_application" "app" {
+  for_each = toset([var.cloudflare_ssh_subdomain, var.cloudflare_postgrest_subdomain])
+
+  zone_id          = local.cloudflare_zone_id
+  name             = "${each.key}.${var.cloudflare_zone}"
+  domain           = "${each.key}.${var.cloudflare_zone}"
+  session_duration = "1h"
+}
+
+# Access policy that the above appplication uses. (i.e. who is allowed in)
+resource "cloudflare_access_policy" "user_email" {
+  for_each = toset([var.cloudflare_ssh_subdomain, var.cloudflare_postgrest_subdomain])
+
+  application_id = cloudflare_access_application.app[each.key].id
+  zone_id        = local.cloudflare_zone_id
+  name           = "${each.key}.${var.cloudflare_zone}"
+  precedence     = "1"
+  decision       = "allow"
+
+  include {
+    email = [var.cloudflare_email]
+  }
+}
+
+# Access service token that can be used from Workers
+resource "cloudflare_access_service_token" "postgrest_example_worker" {
+  account_id = var.cloudflare_account_id
+  name       = "PostgREST example Worker service token"
+}
+
+# Access policy to allow Worker using service tokens 
+resource "cloudflare_access_policy" "postgrest_example_worker" {
+  application_id = cloudflare_access_application.app[var.cloudflare_postgrest_subdomain].id
+  zone_id        = local.cloudflare_zone_id
+  name           = "${var.cloudflare_postgrest_subdomain}.${var.cloudflare_zone}"
+  precedence     = "2"
+  decision       = "non_identity"
+
+  include {
+    service_token = [cloudflare_access_service_token.postgrest_example_worker.id]
+  }
+}

--- a/terraform-zerotrust-postgrest-worker/cloudflare-tunnel.tf
+++ b/terraform-zerotrust-postgrest-worker/cloudflare-tunnel.tf
@@ -1,0 +1,22 @@
+# The random_id resource is used to generate a 35 character secret for the tunnel
+resource "random_id" "tunnel_secret" {
+  byte_length = 35
+}
+
+# A Named Tunnel resource called zero_trust_postgrest
+resource "cloudflare_argo_tunnel" "auto_tunnel" {
+  account_id = var.cloudflare_account_id
+  name       = "zero_trust_postgrest"
+  secret     = random_id.tunnel_secret.b64_std
+}
+
+# DNS settings to CNAME to tunnel target for HTTP application
+resource "cloudflare_record" "cloudflare_tunnel" {
+  for_each = toset([var.cloudflare_ssh_subdomain, var.cloudflare_postgrest_subdomain])
+
+  zone_id = local.cloudflare_zone_id
+  name    = "${each.key}.${var.cloudflare_zone}"
+  value   = "${cloudflare_argo_tunnel.auto_tunnel.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+}

--- a/terraform-zerotrust-postgrest-worker/cloudflare-worker-script.js
+++ b/terraform-zerotrust-postgrest-worker/cloudflare-worker-script.js
@@ -1,0 +1,43 @@
+addEventListener("fetch", event => {
+    return event.respondWith(handleRequest(event.request))
+})
+
+async function handleRequest(request) {
+    // parse the URL and get someId
+    const url = new URL(request.url)
+
+    let postgrestParams = new URLSearchParams();
+    let postgrestMethod
+    let postgrestBody
+
+    // if path starts with /new-random-visit, generate a random user and send data to database
+    if(url.pathname.startsWith("/new")) {
+        const res = await fetch("https://randomuser.me/api/")
+        const randomUser = (await res.json()).results[0]
+        postgrestMethod = "POST"
+        postgrestBody = [{
+            username: randomUser.login.username,
+            country: randomUser.location.country.toLowerCase(),
+            time: new Date().toISOString(),
+        }]
+    } else {
+        postgrestMethod = "GET"
+        // if country set, filter results
+        const country = url.searchParams.get("country")
+        if (country) {
+            postgrestParams.append("country", `eq.${country.toLocaleLowerCase()}`)
+        }
+        postgrestParams.append("order", "time.desc")
+    }
+    
+    // proxy the request to postgrest endpoint
+    return fetch(`${POSTGREST_ENDPOINT}/visits?${postgrestParams.toString()}`, {
+        method: postgrestMethod,
+        body: JSON.stringify(postgrestBody),
+        headers: {
+            'Content-Type': 'application/json',
+            'CF-Access-Client-Id': CF_ACCESS_CLIENT_ID,
+            'CF-Access-Client-Secret': CF_ACCESS_CLIENT_SECRET,
+        }
+    })
+}

--- a/terraform-zerotrust-postgrest-worker/cloudflare-worker.tf
+++ b/terraform-zerotrust-postgrest-worker/cloudflare-worker.tf
@@ -1,0 +1,33 @@
+resource "cloudflare_record" "postgrest_worker" {
+  zone_id = local.cloudflare_zone_id
+  name    = "${var.cloudflare_worker_subdomain}.${var.cloudflare_zone}"
+  value   = "100::"
+  type    = "AAAA"
+  proxied = true
+}
+
+resource "cloudflare_worker_script" "postgrest_worker" {
+  name    = "zerotrust-worker-example"
+  content = file("cloudflare-worker-script.js")
+
+  plain_text_binding {
+    name = "POSTGREST_ENDPOINT"
+    text = "https://${var.cloudflare_postgrest_subdomain}.${var.cloudflare_zone}"
+  }
+
+  secret_text_binding {
+    name = "CF_ACCESS_CLIENT_ID"
+    text = cloudflare_access_service_token.postgrest_example_worker.client_id
+  }
+
+  secret_text_binding {
+    name = "CF_ACCESS_CLIENT_SECRET"
+    text = cloudflare_access_service_token.postgrest_example_worker.client_secret
+  }
+}
+
+resource "cloudflare_worker_route" "postgrest_worker" {
+  zone_id     = local.cloudflare_zone_id
+  pattern     = "${var.cloudflare_worker_subdomain}.${var.cloudflare_zone}/*"
+  script_name = cloudflare_worker_script.postgrest_worker.name
+}

--- a/terraform-zerotrust-postgrest-worker/gcp-instance-startup-script.tpl
+++ b/terraform-zerotrust-postgrest-worker/gcp-instance-startup-script.tpl
@@ -1,0 +1,87 @@
+# Script to install Cloudflare Tunnel and Docker resources
+# Docker configuration
+cd /tmp
+ 
+# Retrieveing the docker repository for this OS
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+# The OS is updated and docker is installed
+sudo apt update -y && sudo apt upgrade -y
+sudo apt install docker docker-compose -y 
+
+# This is a herefile that is used to populate the /tmp/docker-compose.yml file. This logic is used elsewhere in this script 
+# Inspired by https://postgrest.org/en/v7.0.0/install.html
+cat > /tmp/docker-compose.yml << "EOF"
+version: '3'
+services:
+  server:
+    image: postgrest/postgrest
+    ports:
+      - "3000:3000"
+    links:
+      - db:db
+    environment:
+      PGRST_DB_URI: postgres://app_user:${postgresql_password}@db:5432/app_db
+      PGRST_DB_SCHEMA: public
+      PGRST_DB_ANON_ROLE: app_user # In production this role should not be the same as the one used for the connection
+      PGRST_SERVER_PROXY_URI: "http://127.0.0.1:3000"
+    depends_on:
+      - db
+  db:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: app_db
+      POSTGRES_USER: app_user
+      POSTGRES_PASSWORD: ${postgresql_password}
+    volumes:
+      - "./pgdata:/var/lib/postgresql/data"
+EOF
+
+# cloudflared configuration
+cd
+# The package for this OS is retrieved 
+wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb
+sudo dpkg -i cloudflared-stable-linux-amd64.deb
+# A local user directory is first created before we can install the tunnel as a system service 
+mkdir ~/.cloudflared
+# Another herefile is used to dynamically populate the JSON credentials file 
+cat > ~/.cloudflared/cert.json << "EOF"
+{
+    "AccountTag"   : "${cf_account_id}",
+    "TunnelID"     : "${cf_tunnel_id}",
+    "TunnelName"   : "${cf_tunnel_name}",
+    "TunnelSecret" : "${cf_tunnel_secret}"
+}
+EOF
+# Same concept with the Ingress Rules the tunnel will use
+# Remove any default conflicting config and create a new one
+rm /etc/cloudflared/config.yml
+cat > ~/.cloudflared/config.yml << "EOF"
+tunnel: ${cf_tunnel_id}
+credentials-file: /etc/cloudflared/cert.json
+logfile: /var/log/cloudflared.log
+loglevel: info
+
+ingress:
+  - hostname: "*"
+    path: "^/_healthcheck$"
+    service: http_status:200
+  - hostname: ${postgrest_subdomain}.${cf_zone}
+    service: http://localhost:3000
+  - hostname: ${ssh_subdomain}.${cf_zone}
+    service: ssh://localhost:22
+  - service: http_status:404
+EOF
+# Now we install the tunnel as a systemd service 
+sudo cloudflared service install
+# The credentials file does not get copied over so we'll do that manually 
+sudo cp -via ~/.cloudflared/cert.json /etc/cloudflared/
+# Now we can bring up our container(s) with docker-compose and then start the tunnel 
+cd /tmp
+sudo docker-compose up -d && sudo service cloudflared start
+
+# create example db and schema we will use from our example Worker
+sleep 10
+sudo docker exec tmp_db_1 psql -U app_user -d app_db -c "CREATE TABLE public.visits (username text, country text, time timestamptz);"

--- a/terraform-zerotrust-postgrest-worker/gcp-instance-startup-script.tpl
+++ b/terraform-zerotrust-postgrest-worker/gcp-instance-startup-script.tpl
@@ -50,7 +50,7 @@ sudo dpkg -i cloudflared-stable-linux-amd64.deb
 # A local user directory is first created before we can install the tunnel as a system service 
 mkdir ~/.cloudflared || echo ~/.cloudflared already exists
 # Another herefile is used to dynamically populate the JSON credentials file
-cat <<EOF > ~/.cloudflared/cert.json
+cat <<EOF > ~/.cloudflared/creds.json
 {
     "AccountTag"   : "${cf_account_id}",
     "TunnelID"     : "${cf_tunnel_id}",
@@ -64,7 +64,7 @@ EOF
 rm /etc/cloudflared/config.yml
 cat <<EOF > ~/.cloudflared/config.yml
 tunnel: ${cf_tunnel_id}
-credentials-file: /etc/cloudflared/cert.json
+credentials-file: /etc/cloudflared/creds.json
 logfile: /var/log/cloudflared.log
 loglevel: info
 
@@ -81,7 +81,7 @@ EOF
 
 # The credentials file does not get copied over so we'll do that manually 
 mkdir /etc/cloudflared || echo /etc/cloudflared already exists
-yes | sudo cp -via ~/.cloudflared/cert.json /etc/cloudflared/
+yes | sudo cp -via ~/.cloudflared/creds.json /etc/cloudflared/
 # Now we install the tunnel as a systemd service 
 sudo cloudflared service install
 # Now we can bring up our container(s) with docker-compose and then start the tunnel 

--- a/terraform-zerotrust-postgrest-worker/gcp-instance.tf
+++ b/terraform-zerotrust-postgrest-worker/gcp-instance.tf
@@ -1,0 +1,50 @@
+# OS the server will use
+data "google_compute_image" "image" {
+  family  = "ubuntu-minimal-2004-lts"
+  project = "ubuntu-os-cloud"
+}
+
+resource "random_password" "postgresql_password" {
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+
+# GCP Instance resource 
+resource "google_compute_instance" "origin" {
+  name         = "zerotrust-postgrest-example"
+  machine_type = var.gcp_machine_type
+  zone         = var.gcp_zone
+  // Your tags may differ. This one instructs the networking to not allow access to port 22
+  tags = ["no-ssh"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+  // Optional config to make instance ephemeral 
+  scheduling {
+    preemptible       = true
+    automatic_restart = false
+  }
+  // This is where we configure the server (aka instance) on startup.
+  metadata_startup_script = templatefile("./gcp-instance-startup-script.tpl",
+    {
+      ssh_subdomain       = var.cloudflare_ssh_subdomain,
+      postgrest_subdomain = var.cloudflare_postgrest_subdomain,
+      postgresql_password = random_password.postgresql_password.result,
+      cf_account_id       = var.cloudflare_account_id,
+      cf_zone             = var.cloudflare_zone,
+      cf_tunnel_id        = cloudflare_argo_tunnel.auto_tunnel.id,
+      cf_tunnel_name      = cloudflare_argo_tunnel.auto_tunnel.name,
+      cf_tunnel_secret    = random_id.tunnel_secret.b64_std
+  })
+}

--- a/terraform-zerotrust-postgrest-worker/providers.tf
+++ b/terraform-zerotrust-postgrest-worker/providers.tf
@@ -1,0 +1,11 @@
+# Providers
+provider "cloudflare" {
+  email      = var.cloudflare_email
+  account_id = var.cloudflare_account_id
+  api_key    = var.cloudflare_token
+}
+provider "google" {
+  project = var.gcp_project_id
+}
+
+provider "random" {}

--- a/terraform-zerotrust-postgrest-worker/variables.tf
+++ b/terraform-zerotrust-postgrest-worker/variables.tf
@@ -56,3 +56,34 @@ variable "cloudflare_token" {
   description = "The Cloudflare user's API token."
   type        = string
 }
+
+# Variables for the bonus "any SSH host" installation
+variable "ssh_host_ip" {
+  description = "The SSH host IP address"
+  type        = string
+  default     = ""
+}
+
+variable "ssh_host_port" {
+  description = "The SSH host port"
+  type        = string
+  default     = 22
+}
+
+variable "ssh_key_path" {
+  description = "The path to your SSH key"
+  type        = string
+  default     = "~/.ssh/my_id_rsa"
+}
+
+variable "ssh_user" {
+  description = "The SSH user"
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_password" {
+  description = "The SSH password"
+  type        = string
+  default     = ""
+}

--- a/terraform-zerotrust-postgrest-worker/variables.tf
+++ b/terraform-zerotrust-postgrest-worker/variables.tf
@@ -1,0 +1,58 @@
+# GCP variables
+variable "gcp_project_id" {
+  description = "Google Cloud Platform (GCP) Project ID."
+  type        = string
+}
+
+variable "gcp_zone" {
+  description = "GCP region name."
+  type        = string
+  default     = "us-east1-b"
+}
+
+variable "gcp_machine_type" {
+  description = "GCP VM instance machine type."
+  type        = string
+  default     = "f1-micro"
+}
+
+# Cloudflare Variables
+variable "cloudflare_zone" {
+  description = "The Cloudflare Zone to use."
+  type        = string
+}
+
+variable "cloudflare_ssh_subdomain" {
+  description = "The SSH subdomain to create."
+  type        = string
+  default     = "zerotrust-ssh-example"
+}
+
+variable "cloudflare_postgrest_subdomain" {
+  description = "The PostgREST subdomain to create."
+  type        = string
+  default     = "zerotrust-postgrest-example"
+}
+
+variable "cloudflare_worker_subdomain" {
+  description = "The example Worker subdomain route to create."
+  type        = string
+  default     = "zerotrust-worker-example"
+}
+
+variable "cloudflare_account_id" {
+  description = "The Cloudflare UUID for the Account the Zone lives in."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_email" {
+  description = "The Cloudflare user."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_token" {
+  description = "The Cloudflare user's API token."
+  type        = string
+}

--- a/terraform-zerotrust-postgrest-worker/versions.tf
+++ b/terraform-zerotrust-postgrest-worker/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+    google = {
+      source = "hashicorp/google"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Hey! 

I wanted to write a guide to run and proxy postgres(t) with Cloudflare tunnel for a while now, then realized I can just take the already existing one written by you and just add the rest. 

**Resources being provisioned**
- GCP instance
   - postgresql 
   - postgrest
   - cloudflared
- Cloudflare tunnel
- Cloudflare Access policies, plus service token for Worker
- Cloudflare DNS records
- Cloudflare Worker that uses Access service token to fetch postgres(t) endpoint

The plan was also to use WARP to demonstrate connect to the instance's private IP directly, but it might be too much. I can perhaps prepare a different Terraform example just for that.