### PR TITLE
new: add gke ingress example

### DIFF
--- a/terraform-gcp-gke-ingress-controller/.gitignore
+++ b/terraform-gcp-gke-ingress-controller/.gitignore
@@ -1,0 +1,33 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+terraform.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+*tfplan*
+*.plan*
+*lock*

--- a/terraform-gcp-gke-ingress-controller/README.md
+++ b/terraform-gcp-gke-ingress-controller/README.md
@@ -1,0 +1,67 @@
+# GCP Kubernetes cluster with Nginx Ingress Controller behind Cloudflare Tunnel
+
+## Requirements
+
+- Terraform version 0.15+
+- GCP (Google Cloud) CLI setup and [authenticated to a GCP project](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) with compute access. 
+- Helm CLI [installed](https://helm.sh/docs/intro/install/)
+
+## Deployment
+1. Copy repo to your local workstation
+2. Change directory (cd) to the example's location on your local workstation
+3. Set the following environment variables
+    ```bash
+    # required
+    export TF_VAR_gcp_project_id=
+    export TF_VAR_cloudflare_account_id=
+    export TF_VAR_cloudflare_zone=
+    export TF_VAR_cloudflare_email=
+    export TF_VAR_cloudflare_token=
+    # optional, defaults to following values
+    export TF_VAR_gcp_zone=us-east1-b
+    ```
+4. Run `terraform init` and `terraform apply` to deploy the full stack
+
+## Setup
+
+Typically takes ~5 mins to fully spin up. 
+
+This demo 
+- Creates a Google Cloud (GCP) Kubernetes Engine (GKE)
+- Spins up `nginx-ingress-controller` on GKE cluster using Helm
+- Spins up a Cloudflare Tunnel with 2 replicas on GKE cluster and points it to the `nginx-ingress-controller`
+- Creates Cloudflare token for managing DNS records in the specified zone and creates Kubernetes secret for `external-dns`
+- Spins up `external-dns` to automatically manage DNS records pointing to Cloudflare Tunnel for any Kubernetes ingress resources that use specified Cloudflare zone domain
+- Spins up example applications demonstrating all above
+  - `docker-helloworld` (https://docker-helloworld.yourzone.com)
+  - `echoserver` (https://echoserver.yourzone.com)
+  - `httpbin` (https://httpbin.yourzone.com)
+
+### Cloudflare Tunnel 
+Deployed Cloudflare Tunnel proxied all traffic to the `nginx-ingress-controller`, which handles the load-balancing based on the ingress resources.
+
+### External DNS
+Deployed external-dns automatically create and manage DNS records in your zone pointing to the Cloudflare Tunnel.
+
+Example of Ingress resource that will expose Kubernetes service through Cloudflare Tunnel by creating a CNAME of `httpbin.yourzone.com` pointing to `gke-tunnel-origin.yourzone.com`.
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    # gke-tunnel-origin.yourzone.com is not proxied CNAME to your tunnel
+    # it is created by Terraform in cloudflare-tunnel.tf
+    external-dns.alpha.kubernetes.io/target: gke-tunnel-origin.yourzone.com
+    kubernetes.io/ingress.class: nginx
+  name: httpbin
+  namespace: httpbin
+spec:
+  rules:
+  - host: httpbin.yourzone.com
+    http:
+      paths:
+      - backend:
+          serviceName: httpbin
+          servicePort: 80
+```

--- a/terraform-gcp-gke-ingress-controller/cloudflare-api-token.tf
+++ b/terraform-gcp-gke-ingress-controller/cloudflare-api-token.tf
@@ -1,0 +1,28 @@
+# Lookup for zone ID from the zone name
+data "cloudflare_zones" "zones" {
+  filter {
+    name        = var.cloudflare_zone
+    lookup_type = "exact"
+    status      = "active"
+  }
+}
+
+locals {
+  cloudflare_zone_id = lookup(element(data.cloudflare_zones.zones.zones, 0), "id")
+}
+
+data "cloudflare_api_token_permission_groups" "all" {}
+
+# Token allowed to edit DNS entries for specific zone.
+resource "cloudflare_api_token" "zone_dns_edit" {
+  name = "terraform-gke-dns-edit"
+
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.permissions["DNS Write"],
+    ]
+    resources = {
+      "com.cloudflare.api.account.zone.${local.cloudflare_zone_id}" = "*"
+    }
+  }
+}

--- a/terraform-gcp-gke-ingress-controller/cloudflare-tunnel.tf
+++ b/terraform-gcp-gke-ingress-controller/cloudflare-tunnel.tf
@@ -1,0 +1,21 @@
+# The random_id resource is used to generate a 35 character secret for the tunnel
+resource "random_id" "tunnel_secret" {
+  byte_length = 35
+}
+
+# A Named Tunnel resource called terraform-gcp-gke
+resource "cloudflare_argo_tunnel" "gke_tunnel" {
+  account_id = var.cloudflare_account_id
+  name       = "terraform-gcp-gke"
+  secret     = random_id.tunnel_secret.b64_std
+}
+
+# DNS settings to CNAME to tunnel target for k8s Ingresses
+# Not proxied, not accessible. Just a record for auto-created CNAMEs by external-dns.
+resource "cloudflare_record" "gke_tunnel" {
+  zone_id = local.cloudflare_zone_id
+  name    = "gke-tunnel-origin.${var.cloudflare_zone}"
+  value   = "${cloudflare_argo_tunnel.gke_tunnel.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = false
+}

--- a/terraform-gcp-gke-ingress-controller/gcp-gke-cluster.tf
+++ b/terraform-gcp-gke-ingress-controller/gcp-gke-cluster.tf
@@ -1,0 +1,19 @@
+resource "google_container_cluster" "example" {
+  name               = "terraform-example-gke"
+  location           = var.gcp_zone
+  initial_node_count = 2
+
+  node_config {
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+    preemptible = true
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/terraform-gcp-gke-ingress-controller/k8s-cloudflared.tf
+++ b/terraform-gcp-gke-ingress-controller/k8s-cloudflared.tf
@@ -1,0 +1,123 @@
+resource "kubernetes_namespace" "cloudflared" {
+  metadata {
+    name        = "cloudflared"
+    annotations = {}
+    labels      = {}
+  }
+}
+
+resource "kubernetes_deployment" "cloudflared" {
+  metadata {
+    name      = "cloudflared"
+    namespace = kubernetes_namespace.cloudflared.metadata[0].name
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "cloudflared"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "cloudflared"
+        }
+      }
+
+      spec {
+        volume {
+          name = "creds"
+          secret {
+            secret_name = "cloudflared"
+          }
+        }
+
+        volume {
+          name = "config"
+          config_map {
+            name = "cloudflared"
+          }
+        }
+
+        container {
+          image = "cloudflare/cloudflared:2021.5.10"
+          name  = "cloudflared"
+          args  = ["tunnel", "--config", "/etc/cloudflared/config/config.yaml", "run"]
+
+          liveness_probe {
+            http_get {
+              path = "/ready"
+              port = 2000
+            }
+
+            initial_delay_seconds = 1
+            period_seconds        = 10
+            failure_threshold     = 1
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/etc/cloudflared/config"
+            read_only  = true
+          }
+
+          volume_mount {
+            name       = "creds"
+            mount_path = "/etc/cloudflared/creds"
+            read_only  = true
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_config_map" "cloudflared" {
+  metadata {
+    name      = "cloudflared"
+    namespace = kubernetes_namespace.cloudflared.metadata[0].name
+  }
+
+  data = {
+    "config.yaml" = <<EOT
+# Name of the tunnel you want to run
+tunnel: ${cloudflare_argo_tunnel.gke_tunnel.id}
+credentials-file: /etc/cloudflared/creds/credentials.json
+# Serves the metrics server under /metrics and the readiness server under /ready
+metrics: 0.0.0.0:2000
+# Autoupdates applied in a k8s pod will be lost when the pod is removed or restarted, so
+# autoupdate doesn't make sense in Kubernetes. However, outside of Kubernetes, we strongly
+# recommend using autoupdate.
+no-autoupdate: true
+# The `ingress` block tells cloudflared which local service to route incoming
+# requests to. For more about ingress rules, see
+# https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/ingress
+#
+ingress:
+# This rule sends all requests to nginx ingress controller, which proxies them further to correct services
+- service: http://${helm_release.nginx_ingress.name}.${kubernetes_namespace.nginx_ingress.metadata[0].name}.svc.cluster.local.:80
+EOT
+  }
+}
+
+resource "kubernetes_secret" "cloudflared" {
+  metadata {
+    name      = "cloudflared"
+    namespace = kubernetes_namespace.cloudflared.metadata[0].name
+  }
+
+  data = {
+    "credentials.json" = jsonencode({
+      "AccountTag"   = var.cloudflare_account_id,
+      "TunnelID"     = cloudflare_argo_tunnel.gke_tunnel.id,
+      "TunnelName"   = cloudflare_argo_tunnel.gke_tunnel.name,
+      "TunnelSecret" = random_id.tunnel_secret.b64_std
+    })
+  }
+
+  type = "kubernetes.io/secret"
+}

--- a/terraform-gcp-gke-ingress-controller/k8s-docker-helloworld.tf
+++ b/terraform-gcp-gke-ingress-controller/k8s-docker-helloworld.tf
@@ -1,0 +1,83 @@
+resource "kubernetes_namespace" "docker_helloworld" {
+  metadata {
+    name        = "docker-helloworld"
+    annotations = {}
+    labels      = {}
+  }
+}
+
+resource "kubernetes_deployment" "docker_helloworld" {
+  metadata {
+    name      = "docker-helloworld"
+    namespace = kubernetes_namespace.docker_helloworld.metadata[0].name
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "docker-helloworld"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "docker-helloworld"
+        }
+      }
+
+      spec {
+        container {
+          image = "karthequian/helloworld:latest"
+          name  = "docker-helloworld"
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "docker_helloworld" {
+  metadata {
+    name      = "docker-helloworld"
+    namespace = kubernetes_namespace.docker_helloworld.metadata[0].name
+  }
+
+  spec {
+    selector = {
+      app = kubernetes_deployment.docker_helloworld.spec[0].template[0].metadata[0].labels.app
+    }
+
+    port {
+      protocol = "TCP"
+      port     = 80
+    }
+  }
+}
+
+resource "kubernetes_ingress" "docker_helloworld" {
+  metadata {
+    name      = "docker-helloworld"
+    namespace = kubernetes_namespace.docker_helloworld.metadata[0].name
+    annotations = {
+      "kubernetes.io/ingress.class" : "nginx"
+
+      # this is important, sets correct CNAME to the Cloudflare Tunnel record
+      "external-dns.alpha.kubernetes.io/target" = cloudflare_record.gke_tunnel.hostname
+    }
+  }
+  spec {
+    rule {
+      host = "docker-helloworld.${var.cloudflare_zone}"
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.docker_helloworld.metadata[0].name
+            service_port = 80
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform-gcp-gke-ingress-controller/k8s-echoserver.tf
+++ b/terraform-gcp-gke-ingress-controller/k8s-echoserver.tf
@@ -1,0 +1,83 @@
+resource "kubernetes_namespace" "echoserver" {
+  metadata {
+    name        = "echoserver"
+    annotations = {}
+    labels      = {}
+  }
+}
+
+resource "kubernetes_deployment" "echoserver" {
+  metadata {
+    name      = "echoserver"
+    namespace = kubernetes_namespace.echoserver.metadata[0].name
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "echoserver"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "echoserver"
+        }
+      }
+
+      spec {
+        container {
+          image = "k8s.gcr.io/echoserver:1.4"
+          name  = "echoserver"
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "echoserver" {
+  metadata {
+    name      = "echoserver"
+    namespace = kubernetes_namespace.echoserver.metadata[0].name
+  }
+
+  spec {
+    selector = {
+      app = kubernetes_deployment.echoserver.spec[0].template[0].metadata[0].labels.app
+    }
+
+    port {
+      protocol = "TCP"
+      port     = 8080
+    }
+  }
+}
+
+resource "kubernetes_ingress" "echoserver" {
+  metadata {
+    name      = "echoserver"
+    namespace = kubernetes_namespace.echoserver.metadata[0].name
+    annotations = {
+      "kubernetes.io/ingress.class" : "nginx"
+
+      # this is important, sets correct CNAME to the Cloudflare Tunnel record
+      "external-dns.alpha.kubernetes.io/target" = cloudflare_record.gke_tunnel.hostname
+    }
+  }
+  spec {
+    rule {
+      host = "echoserver.${var.cloudflare_zone}"
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.echoserver.metadata[0].name
+            service_port = 8080
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform-gcp-gke-ingress-controller/k8s-external-dns.tf
+++ b/terraform-gcp-gke-ingress-controller/k8s-external-dns.tf
@@ -1,0 +1,49 @@
+resource "kubernetes_namespace" "external_dns" {
+  metadata {
+    name        = "external-dns"
+    annotations = {}
+    labels      = {}
+  }
+}
+
+resource "helm_release" "external_dns" {
+  name = "external-dns"
+
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "external-dns"
+
+  namespace = kubernetes_namespace.external_dns.metadata[0].name
+
+  set {
+    name  = "provider"
+    value = "cloudflare"
+  }
+
+  set {
+    name  = "cloudflare.secretName"
+    value = kubernetes_secret.external_dns.metadata[0].name
+  }
+
+  set {
+    name  = "zoneIdFilters.${local.cloudflare_zone_id}"
+    value = local.cloudflare_zone_id
+  }
+
+  set {
+    name  = "policy"
+    value = "sync"
+  }
+}
+
+resource "kubernetes_secret" "external_dns" {
+  metadata {
+    name      = "external-dns"
+    namespace = kubernetes_namespace.external_dns.metadata[0].name
+  }
+
+  data = {
+    "cloudflare_api_token" = cloudflare_api_token.zone_dns_edit.value
+  }
+
+  type = "kubernetes.io/secret"
+}

--- a/terraform-gcp-gke-ingress-controller/k8s-httpbin.tf
+++ b/terraform-gcp-gke-ingress-controller/k8s-httpbin.tf
@@ -1,0 +1,83 @@
+resource "kubernetes_namespace" "httpbin" {
+  metadata {
+    name        = "httpbin"
+    annotations = {}
+    labels      = {}
+  }
+}
+
+resource "kubernetes_deployment" "httpbin" {
+  metadata {
+    name      = "httpbin"
+    namespace = kubernetes_namespace.httpbin.metadata[0].name
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "httpbin"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "httpbin"
+        }
+      }
+
+      spec {
+        container {
+          image = "kennethreitz/httpbin:latest"
+          name  = "httpbin"
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "httpbin" {
+  metadata {
+    name      = "httpbin"
+    namespace = kubernetes_namespace.httpbin.metadata[0].name
+  }
+
+  spec {
+    selector = {
+      app = kubernetes_deployment.httpbin.spec[0].template[0].metadata[0].labels.app
+    }
+
+    port {
+      protocol = "TCP"
+      port     = 80
+    }
+  }
+}
+
+resource "kubernetes_ingress" "httpbin" {
+  metadata {
+    name      = "httpbin"
+    namespace = kubernetes_namespace.httpbin.metadata[0].name
+    annotations = {
+      "kubernetes.io/ingress.class" : "nginx"
+
+      # this is important, sets correct CNAME to the Cloudflare Tunnel record
+      "external-dns.alpha.kubernetes.io/target" = cloudflare_record.gke_tunnel.hostname
+    }
+  }
+  spec {
+    rule {
+      host = "httpbin.${var.cloudflare_zone}"
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.httpbin.metadata[0].name
+            service_port = 80
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform-gcp-gke-ingress-controller/k8s-nginx-ingress.tf
+++ b/terraform-gcp-gke-ingress-controller/k8s-nginx-ingress.tf
@@ -1,0 +1,21 @@
+resource "kubernetes_namespace" "nginx_ingress" {
+  metadata {
+    name        = "nginx-ingress"
+    annotations = {}
+    labels      = {}
+  }
+}
+
+resource "helm_release" "nginx_ingress" {
+  name = "nginx-ingress-controller"
+
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "nginx-ingress-controller"
+
+  namespace = kubernetes_namespace.nginx_ingress.metadata[0].name
+
+  set {
+    name  = "service.type"
+    value = "ClusterIP"
+  }
+}

--- a/terraform-gcp-gke-ingress-controller/providers.tf
+++ b/terraform-gcp-gke-ingress-controller/providers.tf
@@ -1,0 +1,28 @@
+# Providers
+provider "cloudflare" {
+  email      = var.cloudflare_email
+  account_id = var.cloudflare_account_id
+  api_key    = var.cloudflare_token
+}
+provider "google" {
+  project = var.gcp_project_id
+}
+
+data "google_client_config" "default" {}
+
+provider "helm" {
+  kubernetes {
+    host                   = google_container_cluster.example.endpoint
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.example.master_auth.0.cluster_ca_certificate)
+  }
+}
+
+provider "kubernetes" {
+  host                   = google_container_cluster.example.endpoint
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.example.master_auth.0.cluster_ca_certificate)
+}
+
+
+provider "random" {}

--- a/terraform-gcp-gke-ingress-controller/variables.tf
+++ b/terraform-gcp-gke-ingress-controller/variables.tf
@@ -1,0 +1,34 @@
+# GCP variables
+variable "gcp_project_id" {
+  description = "Google Cloud Platform (GCP) Project ID."
+  type        = string
+}
+
+variable "gcp_zone" {
+  description = "GCP region name."
+  type        = string
+  default     = "us-east1-b"
+}
+
+# Cloudflare Variables
+variable "cloudflare_zone" {
+  description = "The Cloudflare Zone to use."
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "The Cloudflare UUID for the Account the Zone lives in."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_email" {
+  description = "The Cloudflare user."
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_token" {
+  description = "The Cloudflare user's API token."
+  type        = string
+}

--- a/terraform-gcp-gke-ingress-controller/versions.tf
+++ b/terraform-gcp-gke-ingress-controller/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+    google = {
+      source = "hashicorp/google"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Hey 👋

I am about to write some article about exposing nginx-ingress controller with the named tunnels, so I just prepared some example for it. Would be happy for any feedback or suggestions.

tldr;
- Creates a Google Cloud (GCP) Kubernetes Engine (GKE)
- Spins up `nginx-ingress-controller` on GKE cluster using Helm
- Spins up a Cloudflare Tunnel with 2 replicas on GKE cluster and points it to the `nginx-ingress-controller`
- Creates Cloudflare token for managing DNS records in the specified zone and creates Kubernetes secret for `external-dns`
- Spins up `external-dns` to automatically manage DNS records pointing to Cloudflare Tunnel for any Kubernetes ingress resources that use specified Cloudflare zone domain
- Spins up example applications demonstrating all above
  - `docker-helloworld` (https://docker-helloworld.yourzone.com)
  - `echoserver` (https://echoserver.yourzone.com)
  - `httpbin` (https://httpbin.yourzone.com)